### PR TITLE
Fix typo in user guide's message replay section

### DIFF
--- a/_site/docs/user-guide/latest/index.html
+++ b/_site/docs/user-guide/latest/index.html
@@ -7225,7 +7225,7 @@ starting offset for each input task using Kafka is echoed out in
 <div class="sect2">
 <h3 id="_the_same_messages_are_being_replayed_multiple_times"><a class="anchor" href="#_the_same_messages_are_being_replayed_multiple_times"></a>The same messages are being replayed multiple times</h3>
 <div class="paragraph">
-<p>Message replay happens when a mesage enters Onyx from an input source,
+<p>Message replay happens when a message enters Onyx from an input source,
 gets processed, and is seen again at a later point in time. Onyx replays
 messages for fault tolerance when it suspects that failure of some sort
 has occurred. You can read about how message replay is implemented, and


### PR DESCRIPTION
I think I've done this in the right place. This looks like a Jekyll project…
